### PR TITLE
add improvements to api

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -21,25 +21,23 @@ package main
 
 type PingService struct{}
 
-func (e PingService) Echo(_ context.Context, req *rpc.RequestParams) (any, error) {
+func (s PingService) Echo(_ context.Context, req *rpc.RequestParams) (any, error) {
 	return "ok", nil
 }
 
+func (s PingService) Register() (string, rpc.RequestMap) {
+	return "PingService", map[string]rpc.RequestFunc{
+		"Ping": s.Echo,
+	}
+}
+
 func main() {
-	server := rpc.NewServer()
-	server.ExecutionTimeout = 15 * time.Second // max time a function should execute for.
-	server.MaxBytesRead = 1 << 20              // (1mb) - the maximum size of the total request payload
-
-	ping := PingService{}
-	pingService := rpc.NewService("PingService")
-	pingService.RegisterMethod("Ping", ping.Echo)
-
-	server.AddService(pingService)
+  server := rpc.NewDefaultServer()
+	server.AddService(PingService{})
 
 	mux := http.NewServeMux()
 	mux.Handle("/rpc", server)
 	log.Fatalln(http.ListenAndServe(":8080", mux))
-}
 ```
 
 You can consume a single ping service resource with this curl request

--- a/example/example.go
+++ b/example/example.go
@@ -11,20 +11,26 @@ import (
 
 type PingService struct{}
 
-func (e PingService) Echo(_ context.Context, req *rpc.RequestParams) (any, error) {
+func (s PingService) Echo(_ context.Context, req *rpc.RequestParams) (any, error) {
 	return "ok", nil
 }
 
+func (s PingService) Register() (string, rpc.RequestMap) {
+	return "PingService", map[string]rpc.RequestFunc{
+		"Ping": s.Echo,
+	}
+}
+
 func main() {
-	server := rpc.NewServer()
-	server.ExecutionTimeout = 15 * time.Second // max time a function should execute for.
-	server.MaxBytesRead = 1 << 20              // (1mb) - the maximum size of the total request payload
+	// Create an rpc server
+	server := rpc.NewServer(rpc.Opts{
+		ExecutionTimeout: 15 * time.Second, // max time a function should execute for.
+		MaxBytesRead:     1 << 20,          // (1mb) - the maximum size of the total request payload
+	})
+	// or use the default servver with
+	// server := rpc.NewDefaultServer()
 
-	ping := PingService{}
-	pingService := rpc.NewService("PingService")
-	pingService.RegisterMethod("Ping", ping.Echo)
-
-	server.AddService(pingService)
+	server.AddService(PingService{})
 
 	mux := http.NewServeMux()
 	mux.Handle("/rpc", server)


### PR DESCRIPTION
this change improves the service registration api. 

Now all services have to implement `rpc.ServiceRegistrar` and add the service and all the methods are registered effectively